### PR TITLE
fix: require cgo for Open

### DIFF
--- a/blockstore.go
+++ b/blockstore.go
@@ -6,12 +6,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
-	"sync/atomic"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
-	"github.com/mattn/go-sqlite3"
 )
 
 // pragmas are sqlite pragmas to be applied at initialization.
@@ -75,48 +73,6 @@ var _ blockstore.Blockstore = (*Blockstore)(nil)
 
 type Options struct {
 	// placeholder
-}
-
-// counter of sqlite drivers registered; guarded by atomic.
-var counter int64
-
-// Open creates a new sqlite3-backed blockstore.
-func Open(path string, _ Options) (*Blockstore, error) {
-	driver := fmt.Sprintf("sqlite3_blockstore_%d", atomic.AddInt64(&counter, 1))
-	sql.Register(driver,
-		&sqlite3.SQLiteDriver{
-			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-				// Execute pragmas on connection creation.
-				for _, p := range pragmas {
-					if _, err := conn.Exec(p, nil); err != nil {
-						return fmt.Errorf("failed to execute sqlite3 init pragma: %s; err: %w", p, err)
-					}
-				}
-				return nil
-			},
-		})
-
-	db, err := sql.Open(driver, path+"?mode=rwc")
-	if err != nil {
-		return nil, fmt.Errorf("failed to open sqlite3 database: %w", err)
-	}
-
-	// Execute init DDLs.
-	for _, ddl := range initDDL {
-		if _, err := db.Exec(ddl); err != nil {
-			return nil, fmt.Errorf("failed to execute sqlite3 init DDL: %s; err: %w", ddl, err)
-		}
-	}
-
-	bs := &Blockstore{db: db}
-
-	// Prepare all statements.
-	for i, p := range statements {
-		if bs.prepared[i], err = db.Prepare(p); err != nil {
-			return nil, fmt.Errorf("failed to prepare statement: %s; err: %w", p, err)
-		}
-	}
-	return bs, nil
 }
 
 func (b *Blockstore) Has(cid cid.Cid) (bool, error) {

--- a/blockstore_cgo.go
+++ b/blockstore_cgo.go
@@ -1,0 +1,53 @@
+//+build cgo
+
+package sqlite3bs
+
+import (
+	"database/sql"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// counter of sqlite drivers registered; guarded by atomic.
+var counter int64
+
+// Open creates a new sqlite3-backed blockstore.
+func Open(path string, _ Options) (*Blockstore, error) {
+	driver := fmt.Sprintf("sqlite3_blockstore_%d", atomic.AddInt64(&counter, 1))
+	sql.Register(driver,
+		&sqlite3.SQLiteDriver{
+			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
+				// Execute pragmas on connection creation.
+				for _, p := range pragmas {
+					if _, err := conn.Exec(p, nil); err != nil {
+						return fmt.Errorf("failed to execute sqlite3 init pragma: %s; err: %w", p, err)
+					}
+				}
+				return nil
+			},
+		})
+
+	db, err := sql.Open(driver, path+"?mode=rwc")
+	if err != nil {
+		return nil, fmt.Errorf("failed to open sqlite3 database: %w", err)
+	}
+
+	// Execute init DDLs.
+	for _, ddl := range initDDL {
+		if _, err := db.Exec(ddl); err != nil {
+			return nil, fmt.Errorf("failed to execute sqlite3 init DDL: %s; err: %w", ddl, err)
+		}
+	}
+
+	bs := &Blockstore{db: db}
+
+	// Prepare all statements.
+	for i, p := range statements {
+		if bs.prepared[i], err = db.Prepare(p); err != nil {
+			return nil, fmt.Errorf("failed to prepare statement: %s; err: %w", p, err)
+		}
+	}
+	return bs, nil
+}

--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -1,3 +1,5 @@
+//+build cgo
+
 package sqlite3bs
 
 import (


### PR DESCRIPTION
We still allow users to reference the rest of the types without CGO to make things easier for users. But we put Open (and the tests) behind a cgo build flag.

This will let us deploy our unified CI.