### PR TITLE
fix: better handle canceled contexts in queries

### DIFF
--- a/blockstore_test.go
+++ b/blockstore_test.go
@@ -143,9 +143,11 @@ func TestAllKeysRespectsContext(t *testing.T) {
 
 	cancel()
 
-	v, ok = <-ch
-	require.Equal(t, cid.Undef, v)
-	require.False(t, ok)
+	received := 0
+	for range ch {
+		received++
+		require.LessOrEqual(t, received, 10, "expected query to be canceled")
+	}
 }
 
 func TestDoubleClose(t *testing.T) {


### PR DESCRIPTION
1. Make sure we don't block forever writing the result.
2. Make sure we stop the query when the context is canceled.
3. Allow receiving one result after the context is canceled, the query could have been writing it and may not have checked if the context was canceled yet.